### PR TITLE
perf: refactored code to enhance performance

### DIFF
--- a/src/piece_table.rs
+++ b/src/piece_table.rs
@@ -34,6 +34,7 @@ impl PieceTable {
     }
 
     // Reconstruct the full text from the piece table
+    /// Adds the source code to the initialized empty String
     pub fn to_string(&self) -> String {
         let mut result = String::new();
 
@@ -42,23 +43,34 @@ impl PieceTable {
                 BufferKind::Original => &self.original,
                 BufferKind::Add => &self.add,
             };
+
+            // Takes the range of the string in terms of the index, from the beginning to the end
             result.push_str(&source[piece.start..(piece.start + piece.len)]);
         }
 
         result
     }
 
-    pub fn delete(&mut self, pos: usize, len: usize) {
+    pub fn delete(&mut self, pos: usize, len: usize) -> Result<(), String> {
+        let doc_len: usize = self.pieces.iter().map(|p| p.len).sum();
+        if pos > doc_len {
+            return Err(format!(
+                "insert position {pos} is out of bounds (document length is {doc_len})"
+            ));
+        }
         let mut offset = 0usize;
         for i in 0..self.pieces.len() {
             let piece = self.pieces[i];
 
-            if pos >= offset && pos <= (offset + piece.len) {
+            if pos >= offset && pos < (offset + piece.len) {
                 let split = pos - offset;
 
                 // Guard to prevent overflow
                 if split + len > piece.len {
-                    break;
+                    return Err(format!(
+                        "invalid delete range: {pos} {len} exceeds bounds of current piece ({}, {offset})",
+                        piece.len
+                    ));
                 }
 
                 let left_piece = Piece {
@@ -80,42 +92,104 @@ impl PieceTable {
             }
             offset += piece.len;
         }
+        Ok(())
     }
 
-    pub fn insert(&mut self, pos: usize, text: &str) {
+    /// Inserts `text` at the given document position `pos`.
+    ///
+    /// The document is represented as a list of pieces. Each piece points to a
+    /// slice of either the original buffer or the add buffer. To insert, we find
+    /// which piece contains `pos`, split it in two, and insert a new piece in
+    /// between pointing to the newly added text.
+    pub fn insert(&mut self, pos: usize, text: &str) -> Result<(), String> {
+        // Record where in the add buffer this new text will start, then append it.
+        // We do this first so the add buffer is ready before we touch the pieces.
         let add_start = self.add.len();
-        self.add.push_str(text);
 
+        if text.is_empty() {
+            return Ok(());
+        } else {
+            self.add.push_str(text);
+        }
+
+        let doc_len: usize = self.pieces.iter().map(|p| p.len).sum();
+        if pos > doc_len {
+            return Err(format!(
+                "insert position {pos} is out of bounds (document length is {doc_len})"
+            ));
+        }
+
+        // `offset` tracks the cumulative document position at the start of each piece as we walk through the list. It starts at 0 (the beginning of the document) and advances by each piece's length each iteration.
         let mut offset = 0usize;
+
+        let mut inserted = false;
+
         for i in 0..self.pieces.len() {
             let piece = self.pieces[i];
-            if pos >= offset && pos <= (offset + piece.len) {
+
+            // Check if `pos` falls within this piece's document range.
+            // `offset` is where this piece starts, `offset + piece.len` is where it ends. If `pos` is outside this range, skip to the next piece.
+            // Add boundary check cases
+            if pos >= offset && pos < (offset + piece.len) {
+                // `split` is the local offset — how far into this specific piece the insertion point falls. Subtracting `offset` (the piece's document start position) from `pos` converts from a global document position to a position relative to this piece.
+                // Example: if this piece starts at document position 5 and we want to insert at document position 7, split = 7 - 5 = 2, meaning we cut 2 characters into this piece.
                 let split = pos - offset;
 
+                // Everything in the current piece before the insertion point.
+                // Starts at the same place as the original piece, but is shortened to `split` characters.
                 let left_piece = Piece {
                     buffer: piece.buffer,
                     start: piece.start,
                     len: split,
                 };
+
+                // The newly inserted text, pointing to what we just appended to the add buffer.
                 let new_piece = Piece {
                     buffer: BufferKind::Add,
                     start: add_start,
                     len: text.len(),
                 };
+
+                // Everything in the current piece after the insertion point.
+                // Its start is shifted forward by `split` to skip past the left portion, and its length is reduced accordingly.
                 let right_piece = Piece {
                     buffer: piece.buffer,
                     start: piece.start + split,
                     len: piece.len - split,
                 };
 
+                // Replace the original piece with the three new pieces in order: [left_piece] [new_piece] [right_piece]
+                // We remove the original first, then insert in reverse order at the same index so they end up in the correct sequence.
+
                 self.pieces.remove(i);
-                self.pieces.insert(i, right_piece);
+
+                // Prevent addition of empty string pieces. If split == 0, len is 0, skip
+                // Insert in reverse order at index i so the final sequence is [left_piece?, new_piece, right_piece?]
+                if split < piece.len {
+                    self.pieces.insert(i, right_piece);
+                }
                 self.pieces.insert(i, new_piece);
-                self.pieces.insert(i, left_piece);
+                if split > 0 {
+                    self.pieces.insert(i, left_piece);
+                }
+                inserted = true;
                 break;
             }
+
+            // `pos` was not in this piece, so advance `offset` by this piece's length to move the window forward to the next piece.
             offset += piece.len;
         }
+
+        // If no piece matched, `pos` is at or beyond the end of the document.
+        // Simply push a new piece pointing to the added text — this handles the append case.
+        if !inserted {
+            self.pieces.push(Piece {
+                buffer: BufferKind::Add,
+                start: add_start,
+                len: text.len(),
+            })
+        }
+        Ok(())
     }
 }
 
@@ -131,40 +205,40 @@ mod tests {
     #[test]
     fn insert_at_start() {
         let mut pt = PieceTable::new("ust".to_string());
-        pt.insert(0, "R");
+        pt.insert(0, "R").expect("Overflow");
         assert_eq!(pt.to_string(), "Rust");
     }
     #[test]
     fn insert_at_middle() {
         let mut pt = PieceTable::new("Hi".to_string());
-        pt.insert(1, "o");
+        pt.insert(1, "o").expect("Overflow");
         assert_eq!(pt.to_string(), "Hoi");
     }
     #[test]
     fn insert_at_end() {
         let mut pt = PieceTable::new("Rust".to_string());
-        pt.insert(4, "acean");
+        pt.insert(4, "acean").expect("Overflow");
         assert_eq!(pt.to_string(), "Rustacean");
     }
 
     #[test]
     fn delete_from_start() {
         let mut pt = PieceTable::new("Rust".to_string());
-        pt.delete(0, 4);
+        pt.delete(0, 4).unwrap();
         assert_eq!(pt.to_string(), "");
     }
 
     #[test]
     fn delete_from_middle() {
         let mut pt = PieceTable::new("Rust".to_string());
-        pt.delete(1, 1);
+        pt.delete(1, 1).unwrap();
         assert_eq!(pt.to_string(), "Rst");
     }
 
     #[test]
     fn delete_from_end() {
         let mut pt = PieceTable::new("Rust".to_string());
-        pt.delete(2, 1);
+        pt.delete(2, 1).unwrap();
         assert_eq!(pt.to_string(), "Rut");
     }
 }

--- a/src/piece_table.rs
+++ b/src/piece_table.rs
@@ -133,7 +133,7 @@ impl PieceTable {
         let add_start = self.add.len();
 
         if text.is_empty() {
-            return Ok(());
+            return Err(format!("Invalid! Text is empty"));
         } else {
             self.add.push_str(text);
         }

--- a/src/piece_table.rs
+++ b/src/piece_table.rs
@@ -34,7 +34,11 @@ impl PieceTable {
     }
 
     // Reconstruct the full text from the piece table
-    /// Adds the source code to the initialized empty String
+    /// Reconstructs the current document text by concatenating the slices
+    /// referenced by the piece table.
+    ///
+    /// The `start` and `len` values stored in each piece are byte-based
+    /// indices into either the original or add buffer.
     pub fn to_string(&self) -> String {
         let mut result = String::new();
 

--- a/src/piece_table.rs
+++ b/src/piece_table.rs
@@ -55,9 +55,21 @@ impl PieceTable {
         let doc_len: usize = self.pieces.iter().map(|p| p.len).sum();
         if pos > doc_len {
             return Err(format!(
-                "insert position {pos} is out of bounds (document length is {doc_len})"
+                "delete position {pos} is out of bounds (document length is {doc_len})"
             ));
         }
+
+        if len == 0 {
+            return Ok(());
+        }
+
+        if len > doc_len - pos {
+            return Err(format!(
+                "delete range [{pos}, {}) is out of bounds (document length is {doc_len})",
+                pos + len
+            ));
+        }
+
         let mut offset = 0usize;
         for i in 0..self.pieces.len() {
             let piece = self.pieces[i];
@@ -95,12 +107,22 @@ impl PieceTable {
         Ok(())
     }
 
-    /// Inserts `text` at the given document position `pos`.
+    /// Inserts `text` at the given byte offset `pos`.
     ///
-    /// The document is represented as a list of pieces. Each piece points to a
-    /// slice of either the original buffer or the add buffer. To insert, we find
-    /// which piece contains `pos`, split it in two, and insert a new piece in
-    /// between pointing to the newly added text.
+    /// # Byte Offsets
+    /// `pos` is a **byte offset**, not a character index. For ASCII text these are the same, but for UTF-8 text they differ. For example, the character
+    /// `é` is 2 bytes, so inserting after it requires `pos = 2`, not `pos = 1`.
+    ///
+    /// Passing a `pos` that splits a multi-byte UTF-8 character will cause a panic when the document is read back, as it produces invalid UTF-8 slices.
+    /// Always ensure `pos` falls on a character boundary.
+    ///
+    /// To find a safe byte offset from a character index, use:
+    /// ```
+    /// let pos = text.char_indices().nth(char_index).map(|(i, _)| i).unwrap_or(text.len());
+    /// ```
+    ///
+    /// # Document Structure
+    /// The document is represented as a list of pieces. Each piece points to a slice of either the original buffer or the add buffer. To insert, we find which piece contains `pos`, split it in two, and insert a new piece in between pointing to the newly added text.
     pub fn insert(&mut self, pos: usize, text: &str) -> Result<(), String> {
         // Record where in the add buffer this new text will start, then append it.
         // We do this first so the add buffer is ready before we touch the pieces.
@@ -205,19 +227,19 @@ mod tests {
     #[test]
     fn insert_at_start() {
         let mut pt = PieceTable::new("ust".to_string());
-        pt.insert(0, "R").expect("Overflow");
+        pt.insert(0, "R").unwrap();
         assert_eq!(pt.to_string(), "Rust");
     }
     #[test]
     fn insert_at_middle() {
         let mut pt = PieceTable::new("Hi".to_string());
-        pt.insert(1, "o").expect("Overflow");
+        pt.insert(1, "o").unwrap();
         assert_eq!(pt.to_string(), "Hoi");
     }
     #[test]
     fn insert_at_end() {
         let mut pt = PieceTable::new("Rust".to_string());
-        pt.insert(4, "acean").expect("Overflow");
+        pt.insert(4, "acean").unwrap();
         assert_eq!(pt.to_string(), "Rustacean");
     }
 

--- a/src/piece_table.rs
+++ b/src/piece_table.rs
@@ -158,11 +158,11 @@ impl PieceTable {
             // Add boundary check cases
             if pos >= offset && pos < (offset + piece.len) {
                 // `split` is the local offset — how far into this specific piece the insertion point falls. Subtracting `offset` (the piece's document start position) from `pos` converts from a global document position to a position relative to this piece.
-                // Example: if this piece starts at document position 5 and we want to insert at document position 7, split = 7 - 5 = 2, meaning we cut 2 characters into this piece.
+                // Example: if this piece starts at document position 5 and we want to insert at document position 7, split = 7 - 5 = 2, meaning we cut 2 bytes into this piece.
                 let split = pos - offset;
 
                 // Everything in the current piece before the insertion point.
-                // Starts at the same place as the original piece, but is shortened to `split` characters.
+                // Starts at the same place as the original piece, but is shortened to `split` bytes.
                 let left_piece = Piece {
                     buffer: piece.buffer,
                     start: piece.start,


### PR DESCRIPTION
This pull request improves the robustness and clarity of the `PieceTable` implementation by adding error handling to the `insert` and `delete` methods, enhancing documentation, and updating tests to handle possible errors. The changes make the code safer and easier to maintain, especially when dealing with invalid positions or ranges.

**Error handling and API improvements:**

* The `insert` and `delete` methods of `PieceTable` now return `Result<(), String>` instead of `()`, providing detailed error messages when called with invalid positions or ranges. This prevents panics and allows callers to handle errors gracefully. [[1]](diffhunk://#diff-43847807b414be3fbb875100a67f67046a9edd74a883c585e6064bff72e6a9c8R46-R73) [[2]](diffhunk://#diff-43847807b414be3fbb875100a67f67046a9edd74a883c585e6064bff72e6a9c8R95-R192)
* The test cases for `insert` and `delete` have been updated to use `.expect()` or `.unwrap()`, ensuring that any failure to insert or delete due to invalid input will cause the test to fail with a clear message.

**Documentation and code clarity:**

* Added and improved inline documentation for the `to_string`, `insert`, and related methods, making the code easier to understand for future maintainers. [[1]](diffhunk://#diff-43847807b414be3fbb875100a67f67046a9edd74a883c585e6064bff72e6a9c8R37) [[2]](diffhunk://#diff-43847807b414be3fbb875100a67f67046a9edd74a883c585e6064bff72e6a9c8R95-R192)
* Improved boundary checks and added comments in the `insert` and `delete` methods to clarify how positions are validated and how pieces are manipulated during these operations. [[1]](diffhunk://#diff-43847807b414be3fbb875100a67f67046a9edd74a883c585e6064bff72e6a9c8R46-R73) [[2]](diffhunk://#diff-43847807b414be3fbb875100a67f67046a9edd74a883c585e6064bff72e6a9c8R95-R192)